### PR TITLE
Amendment to RFC 7: Address negative vote fast-failure

### DIFF
--- a/rfc/0007-community-team.md
+++ b/rfc/0007-community-team.md
@@ -233,7 +233,7 @@ The election has **failed** when one of the following is true:
 * A week has passed and less than 75% of the community team and administrative board has voted
 * A week has passed, at least 75% of the community team and administrative board has voted, and those that have
   voted have reached a consensus in opposition of the candidate - or a consensus cannot be reached
-* The candidate receives more negative votes than positive votes
+* An absolute majority of the community team and administrative board has voted against the candidate
 
 If a situation occurs that this section is unable to cover, it will be amended. In those situations, the election will
 fail and need to be restarted after the relevant changes have been made to address the issue.

--- a/rfc/0007-community-team.md
+++ b/rfc/0007-community-team.md
@@ -233,7 +233,7 @@ The election has **failed** when one of the following is true:
 * A week has passed and less than 75% of the community team and administrative board has voted
 * A week has passed, at least 75% of the community team and administrative board has voted, and those that have
   voted have reached a consensus in opposition of the candidate - or a consensus cannot be reached
-* An absolute majority of the community team and administrative board has voted against the candidate
+* The candidate recieves more negative votes than the total amount of positive votes and votes not yet submitted
 
 If a situation occurs that this section is unable to cover, it will be amended. In those situations, the election will
 fail and need to be restarted after the relevant changes have been made to address the issue.


### PR DESCRIPTION
### Amend the negative greater than positive votes clause in "Interpreting the Vote"

There may be a situation where the following happens:

 * An election for a candidate has started, with 0 total votes.
 * An opposing voter casts their votes against the candidate, leaving the poll at 0 positive votes and 1 negative vote.
 * Due to this clause, the election _fails immediately_ because there are a greater amount of negative votes than positive votes (1 negative > 0 positive).

This allows (even accidentally) for a voter to singlehandedly fail an election, even if the candidate would have been passed by the whole voter pool.

To prevent this possibility, the condition is amended to fail the election if an absolute majority of the voters have voted against the candidate, instead of only a simple majority.

Originally, I intended to remove the clause entirely, but further discussion in the Community discord led me to change from removal to amendment; the clause was originally intended to allow an election to fail immediately if more than half of all the possible votes (an absolute majority). This amends the clause to follow the original spirit. 