### PR TITLE
Change Quilt Installer Team

### DIFF
--- a/rfc/0018-technical-teams.md
+++ b/rfc/0018-technical-teams.md
@@ -34,9 +34,9 @@ The following is a list of top-level technical teams.
 
 | Team | Repositories | Notes
 |-|-|-|
-| Quilt Loader | [Quilt Loader](https://github.com/QuiltMC/quilt-loader)<br>[Sat4j](https://github.com/QuiltMC/quilt-loader-sat4j)<br>[Access Widener](https://github.com/QuiltMC/access-widener)<br>[Mixin](https://github.com/QuiltMC/Mixin)<br>[Quilt JSON5](https://github.com/QuiltMC/quilt-json5)
+| Quilt Loader | [Quilt Loader](https://github.com/QuiltMC/quilt-loader)<br>[Quilt Installer](https://github.com/QuiltMC/quilt-installer)<br>[Sat4j](https://github.com/QuiltMC/quilt-loader-sat4j)<br>[Access Widener](https://github.com/QuiltMC/access-widener)<br>[Mixin](https://github.com/QuiltMC/Mixin)<br>[Quilt JSON5](https://github.com/QuiltMC/quilt-json5)
 | Quilt Standard Libraries | [Quilt Standard Libraries](https://github.com/QuiltMC/quilt-standard-libraries)<sup>TBD</sup>| Will contain additional teams for each library
-| Infrastructure | [Quilt Installer](https://github.com/QuiltMC/quilt-installer)<br>[Quilt Meta](https://github.com/QuiltMC/quilt-meta)
+| Infrastructure | [Quilt Meta](https://github.com/QuiltMC/quilt-meta)
 | Mappings | [Yarn](https://github.com/QuiltMC/yarn)<br>[Intermediary](https://github.com/QuiltMC/intermediary)<br>[Matcher](https://github.com/QuiltMC/matcher)<br>[Matcher MC](https://github.com/QuiltMC/matcher-mc)<br>[Enigma](https://github.com/QuiltMC/yarn)<br>[Lorenz Tiny](https://github.com/QuiltMC/lorenz-tiny)<br>[Stitch](https://github.com/QuiltMC/stitch)<br>[Tiny Mappings Parser](https://github.com/QuiltMC/tiny-mappings-parser)<br>[Tiny Remapper](https://github.com/QuiltMC/tiny-remapper)
 | Build Tools | [Quilt Loom](https://github.com/QuiltMC/quilt-loom)<br>[Gradle Convention Plugins](https://github.com/QuiltMC/gradle-convention-plugins)<br>[Sponge Mixin Compile Extensions](https://github.com/QuiltMC/sponge-mixin-compile-extensions)<br>[Dev Launch Injector](https://github.com/QuiltMC/dev-launch-injector)| This team will also be responsible for developing a replacement for Quilt Loom when it becomes possible to do so
 | Decompilers | [Quiltflower](https://github.com/QuiltMC/quiltflower)<br>[CFR](https://github.com/QuiltMC/cfr)<br>[Procyon](https://github.com/QuiltMC/procyon)


### PR DESCRIPTION
This pull request makes Quilt Installer part of the loader team's responsibility, rather than the infrastructure team. The reasoning here is that while Installer does *use* Meta, it doesn't require any actual infrastructure. One concern here is that the infrastructure team is now responsible for a single project. In the future, it's possible that any Maven-related projects would fall under this team, but having a team with such small scope isn't necessarily a bad thing.

Since this is such a small change, I'll leave it open for 48 hours until 4:30PM UTC on Friday, June 4th when I'll merge it unless there are some very good reasons for keeping things as they are.