### PR TITLE
Fix issues found in the QMJ specification during implementation

### DIFF
--- a/loader/0002-quilt.mod.json.md
+++ b/loader/0002-quilt.mod.json.md
@@ -61,11 +61,11 @@ A unique identifier for the organization behind or developers of the mod. The gr
 A unique identifier for the mod or library defined by this file, matching the `^[a-z][a-z0-9-_]{1,63}$` regular expression. Best practice is that mod ID's are in snake_case.
 
 ### The `provides` field
-| Type             | Required |
-|------------------|----------|
-| DependencyObject | False    |
+| Type  | Required |
+|-------|----------|
+| Array | False    |
 
-A [DependencyObject](#dependency-objects) describing other mods/APIs that this package provides.
+An array of [ProvidesObject](#provides-objectss describing other mods/APIs that this package provides.
 
 ### The `version` field
 | Type   | Required |
@@ -402,6 +402,22 @@ Game providers and loader plugins can also add their own optional fields to the 
     "environment": "client"
 }
 ```
+## Provides Objects
+Defines the identifier and optionally version range of another mod that this package provides.
+
+### The `id` field
+| Type   | Required |
+|--------|----------|
+| String | True     |
+
+A mod identifier in the form of either `mavenGroup:modId` or `modId`.
+
+### The `versions` field
+| Type         | Required | Default |
+|--------------|----------|---------|
+| Array/String | False    | `"*"`   |
+
+Should be a [version specifier](#version-specifier) or array of version specifiers defining what versions this dependency applies to. If an array of versions is provided, the dependency matches if it matches ANY of the listed versions.
 
 ## Version Specifier
 A version range specifier can make use of any of the following patterns:

--- a/loader/0002-quilt.mod.json.md
+++ b/loader/0002-quilt.mod.json.md
@@ -51,7 +51,7 @@ Information necessary for the mod loading process.
 |--------|----------|
 | String | True     |
 
-A unique identifier for the organization behind or developers of the mod. See Maven's [guide to naming conventions](https://maven.apache.org/guides/mini/guide-naming-conventions.html).
+A unique identifier for the organization behind or developers of the mod. The group string must match the `^[a-zA-Z0-9-_.]+$` regular expression, and must not begin with the reserved namespace `loader.plugin` It is recommended, but not required, to follow Maven's [guide to naming conventions](https://maven.apache.org/guides/mini/guide-naming-conventions.html).
 
 ### The `id` field
 | Type   | Required |

--- a/loader/0002-quilt.mod.json.md
+++ b/loader/0002-quilt.mod.json.md
@@ -51,7 +51,7 @@ Information necessary for the mod loading process.
 |--------|----------|
 | String | True     |
 
-A unique identifier for the organization behind or developers of the mod. The group string must match the `^[a-zA-Z0-9-_.]+$` regular expression, and must not begin with the reserved namespace `loader.plugin` It is recommended, but not required, to follow Maven's [guide to naming conventions](https://maven.apache.org/guides/mini/guide-naming-conventions.html).
+A unique identifier for the organization behind or developers of the mod. The group string must match the `^[a-zA-Z0-9-_.]+$` regular expression, and must not begin with the reserved namespace `loader.plugin.` It is recommended, but not required, to follow Maven's [guide to naming conventions](https://maven.apache.org/guides/mini/guide-naming-conventions.html).
 
 ### The `id` field
 | Type   | Required |
@@ -403,7 +403,7 @@ Game providers and loader plugins can also add their own optional fields to the 
 }
 ```
 ## Provides Objects
-Defines the identifier and optionally version range of another mod that this package provides.
+Defines the identifier and optionally version range of another mod that this package provides. It can be represented as either an object containing at least [the `id` field](#the-id-field-2), or a string mod identifier in the form of either `mavenGroup:modId` or `modId`.
 
 ### The `id` field
 | Type   | Required |

--- a/loader/0002-quilt.mod.json.md
+++ b/loader/0002-quilt.mod.json.md
@@ -65,7 +65,7 @@ A unique identifier for the mod or library defined by this file, matching the `^
 |-------|----------|
 | Array | False    |
 
-An array of [ProvidesObject](#provides-objectss describing other mods/APIs that this package provides.
+An array of [ProvidesObject](#provides-objects)s describing other mods/APIs that this package provides.
 
 ### The `version` field
 | Type   | Required |


### PR DESCRIPTION
The summary of changes, and their reasoning:
1. Maven groups now have to be alphanumeric or the characters `.`, `-`, or `_` (I am willing to expand this if needed)
2. The maven group namespace `loader.plugin.` is reserved for use by plugins, for example fabric mods would be under the implicit group `loader.plugin.fabric.modid`
     - This isn't enforced for `provides` though, should it be? Or should `provides` not be allowed to define a maven group at all?
3. Provides now uses a `ProvidesObject` instead of a `DependencyObject`--some fields of DependencyObject needlessly complicate implementation or are simply not needed (for example, the array behavior of a dependency object)