### PR TITLE
Add a load type enum field

### DIFF
--- a/loader/0002-quilt.mod.json.md
+++ b/loader/0002-quilt.mod.json.md
@@ -165,11 +165,11 @@ An array of [dependency object](#dependency-objects)s. Defines mods that this mo
 
 Influences whether or not a mod candidate should be loaded or not. May be any of these values:
 
-* "always"
+* "always" (default for mods directly in the mods folder)
 * "if_possible"
 * "if_required" (default for jar-in-jar mods)
 
-This doesn't affect mods directly placed in the mods directory.
+This doesn't affect mods directly placed in the mods folder.
 
 ##### Always
 

--- a/loader/0002-quilt.mod.json.md
+++ b/loader/0002-quilt.mod.json.md
@@ -165,9 +165,9 @@ An array of [dependency object](#dependency-objects)s. Defines mods that this mo
 
 Influences whether or not a mod candidate should be loaded or not. May be any of these values:
 
-* "always"
+* "always" (default for mods directly in the mods folder)
 * "if_possible"
-* "if_required" (default)
+* "if_required" (default for jar-in-jar mods)
 
 This doesn't affect mods directly placed in the mods directory.
 

--- a/loader/0002-quilt.mod.json.md
+++ b/loader/0002-quilt.mod.json.md
@@ -19,7 +19,7 @@ Below is an outline of all defined keys and values.
     * [language_adapters](#the-language_adapters-field) — Array of language adapters
     * [depends](#the-depends-field) — Collection of mod dependencies
     * [breaks](#the-breaks-field) — Collection of mods that this mod is incompatible with
-    * [load_type](#the-load-type-field) — How eagerly to load this mod
+    * [load_type](#the-load_type-field) — How eagerly to load this mod
     * [repositories](#the-repositories-field) — Array of maven repositories
     * [metadata](#the-metadata-field) — Extra information about this mod and/or its authors
         * [name](#the-name-field) — Human-readable name of this mod

--- a/loader/0002-quilt.mod.json.md
+++ b/loader/0002-quilt.mod.json.md
@@ -163,13 +163,25 @@ An array of [dependency object](#dependency-objects)s. Defines mods that this mo
 |---------|----------|
 | String  | False    |
 
-A string, which can be one of the following values:
+Influences whether or not a mod candidate should be loaded or not. May be any of these values:
 
 * "always"
 * "if_possible"
-* "if_required"
+* "if_required" (default)
 
-// TODO: Copy out the rest!
+This doesn't affect mods directly placed in the mods directory.
+
+##### Always
+
+If any versions of this mod are present, then one of them will be loaded.
+
+##### If Possible
+
+If this mod can be loaded, then it will - otherwise it will silently not be loaded.
+
+##### If Required
+
+If this mod is in another mods "depends" field then it will be loaded, otherwise it will silently not be loaded.
 
 ### The `repositories` field
 | Type   | Required |

--- a/loader/0002-quilt.mod.json.md
+++ b/loader/0002-quilt.mod.json.md
@@ -19,6 +19,7 @@ Below is an outline of all defined keys and values.
     * [language_adapters](#the-language_adapters-field) — Array of language adapters
     * [depends](#the-depends-field) — Collection of mod dependencies
     * [breaks](#the-breaks-field) — Collection of mods that this mod is incompatible with
+    * [load_type](#the-load-type-field) — How eagerly to load this mod
     * [repositories](#the-repositories-field) — Array of maven repositories
     * [metadata](#the-metadata-field) — Extra information about this mod and/or its authors
         * [name](#the-name-field) — Human-readable name of this mod
@@ -156,6 +157,19 @@ An array of [dependency object](#dependency-objects)s. Defines mods that this mo
 | Array  | False    |
 
 An array of [dependency object](#dependency-objects)s. Defines mods that this mod either breaks or is broken by.
+
+### The `load_type` field
+| Type    | Required |
+|---------|----------|
+| String  | False    |
+
+A string, which can be one of the following values:
+
+* "always"
+* "if_possible"
+* "if_required"
+
+// TODO: Copy out the rest!
 
 ### The `repositories` field
 | Type   | Required |

--- a/loader/0002-quilt.mod.json.md
+++ b/loader/0002-quilt.mod.json.md
@@ -165,7 +165,7 @@ An array of [dependency object](#dependency-objects)s. Defines mods that this mo
 
 Influences whether or not a mod candidate should be loaded or not. May be any of these values:
 
-* "always" (default for mods directly in the mods folder)
+* "always"
 * "if_possible"
 * "if_required" (default for jar-in-jar mods)
 
@@ -174,6 +174,7 @@ This doesn't affect mods directly placed in the mods directory.
 ##### Always
 
 If any versions of this mod are present, then one of them will be loaded.
+Due to how mod loading actually works if any of the different versions of this mod are present, and one of them has "load_type" set to "always", then all of them are treated as it being set to "always".
 
 ##### If Possible
 


### PR DESCRIPTION
[Rich Diff](https://github.com/QuiltMC/rfcs/pull/30/files?short_path=4f0177c#diff-4f0177c28d2ee6074572764a79131c032c2058b924cf0e25872c2547fed9f736)

In order to support *not* loading modules if they aren't needed I'd like to add a new enum field `load_type` to quilt.mod.json. I should have opened this a while ago, sorry. (This is a port of FabricMC/fabric-loader#342)