### PR TITLE
Emergency fix to 0007 for inactive community members

### DIFF
--- a/structure/0007-community-team.md
+++ b/structure/0007-community-team.md
@@ -227,8 +227,9 @@ the administrative board must be invited to vote on the poll, with their votes c
 voted, they may change their vote or retract it, and their final vote will also count for three. The members of the
 administrative board are not required to vote if they don't feel that it's necessary.
 
-If any voting members of the Community Team don't vote on the poll (unintentionally or otherwise), their vote **must be
-counted as an abstention.**
+If any active voting members of the Community Team don't vote on the poll (unintentionally or otherwise), their vote **must be
+counted as an abstention.** If a member is inactive (has not interacted with communnity management spaces for more than two weeks),
+they will not be counted as a positive vote, negative vote, or abstention, and will not be counted in the tally for voting.
 
 The Community Team should then tally the final vote counts, and interpret them as follows.
 


### PR DESCRIPTION
We have a situation. Two members of the community team have been inactive recently, preventing community team candidates from being elected. I propose this alteration to the process to account for this failure state.

A fault analysis indicates that, since this is only for adding new members, not removing members, it'd require 1) a significant proportion of bad actors on the team already, 2) a majority of non-bad actors to have been away from the project for a significant amount of time, and 3) that to continue for multiple weeks in order to approve enough people to attempt a coup on the community team. These are acceptable failure tolerances since any one of these conditions being met would require the community leadership already being close to dead.
