### PR TITLE
Revise community team removal process

### DIFF
--- a/structure/0007-community-team.md
+++ b/structure/0007-community-team.md
@@ -425,7 +425,10 @@ Eligible voters are decided in allignment with
 [RFC 6: Governmental Structure](/structure/0006-governance.md#removal-of-staff) (anyone above or below), but a
 counterargument is not required or expected before voting or removal of staff permissions. Instead the call to action,
 discussion, and voting can occur in a private channel/dm visible to eligible voters, and if it succeeds the removed
-staff can submit a counterargument asking the decision be overturned after the fact.
+staff can submit a counterargument asking the decision be overturned after the fact. If there are concerns about
+damage to the community, project, or team, a Community Manager or the Key Holder may temporarily revoke staff
+permissions during or before a vote. In the latter case either a vote needs to be initiated or permissions restored
+within a week at the most.
 
 ---
 

--- a/structure/0007-community-team.md
+++ b/structure/0007-community-team.md
@@ -421,7 +421,7 @@ during this process.
 
 ## Process: Removing Team Members
 
-Eligible voters are decided in allignment with
+Eligible voters are decided in alignment with
 [RFC 6: Governmental Structure](/structure/0006-governance.md#removal-of-staff) (anyone above or below), but a
 counterargument is not required or expected before voting or removal of staff permissions. Instead the call to action,
 discussion, and voting can occur in a private channel/dm visible to eligible voters, and if it succeeds the removed

--- a/structure/0007-community-team.md
+++ b/structure/0007-community-team.md
@@ -421,8 +421,11 @@ during this process.
 
 ## Process: Removing Team Members
 
-Removal of members from the community team follows the process outlined in 
-[RFC 6: Governmental Structure](/community/0006-governance.md#removal-of-staff).
+Eligible voters are decided in allignment with
+[RFC 6: Governmental Structure](/structure/0006-governance.md#removal-of-staff) (anyone above or below), but a
+counterargument is not required or expected before voting or removal of staff permissions. Instead the call to action,
+discussion, and voting can occur in a private channel/dm visible to eligible voters, and if it succeeds the removed
+staff can submit a counterargument asking the decision be overturned after the fact.
 
 ---
 


### PR DESCRIPTION
Changes the removal process for community team members not to require a counterargument before acting, and also explicitly outlines that there may be a private place for proposal, discussion, and voting. I think the community team needs the ability to act swiftly and flexibly here, and the staff in question still have an opportunity to respond and request the decision be overturned after the fact. Downside is that they don't necessarily get to know or respond before the result is publicly visible.