### PR TITLE
Change `environment` field to use `dedicated_server` instead of `server`

### DIFF
--- a/specification/0002-quilt.mod.json.md
+++ b/specification/0002-quilt.mod.json.md
@@ -293,7 +293,7 @@ Contains flags and options related to Minecraft specifically.
 Defines the environment(s) that this mod should be loaded on. Valid values are:
 * `"*"` — All environments (default)
 * `"client"` — The physical client
-* `"server"` — The dedicated server
+* `"dedicated_server"` — The dedicated server
 
 ## Custom Elements
 In addition to the defined elements above, mods and libraries will be able to add their own elements to the quilt mod file. Mods will be expected to define up to one top-level element corresponding to their mod id. The element can be of any type, so that mods can define either a single value, array of values, or a sub-object.


### PR DESCRIPTION
Just some cleanup as we prepare Loader for the beta.

I've seen people get confused about how the `environment` field refers to the physical dedicated server and not the logical server, and marking their mods that work fine on an integrated server with the `server` environment. This change will hopefully help reduce this error.

@AlexIIL (the only other active Loader team dev at this time) has signed off on this and this is a trivial change that will be implemented immediately, so this needs little-to-no FCP.