### PR TITLE
RFC 2 amendment: add `intermediate_mappings` field to `quilt.mod.json`

### DIFF
--- a/specification/0002-quilt.mod.json.md
+++ b/specification/0002-quilt.mod.json.md
@@ -197,7 +197,7 @@ A list of Maven repository URL strings where dependencies can be looked for in a
 |--------|----------|------------------------|
 | String | False    | `"org.quiltmc:hashed"` |
 
-The intermediate mappings used for this mod. The intermediate mappings string must be a valid maven coordinate and match the `^[a-zA-Z0-9-_.]+:[a-zA-Z0-9-_.]+$` regular expresson. This field currently only officially supports `org.quiltmc:hashed` and `net.fabricmc:intermediary`.
+The intermediate mappings used for this mod. The intermediate mappings string must be a valid maven coordinate and match the `^[a-zA-Z0-9-_.]+:[a-zA-Z0-9-_.]+$` regular expression. This field currently only officially supports `org.quiltmc:hashed` and `net.fabricmc:intermediary`.
 
 ### The `metadata` field 
 | Type   | Required |

--- a/specification/0002-quilt.mod.json.md
+++ b/specification/0002-quilt.mod.json.md
@@ -193,11 +193,11 @@ If this mod is in another mods "depends" field then it will be loaded, otherwise
 A list of Maven repository URL strings where dependencies can be looked for in addition to Quilt's central repository.
 
 ### The `intermediate_mappings` field
-| Type   | Required | Default    |
-|--------|----------|------------|
-| String | False    | `"hashed"` |
+| Type   | Required | Default                |
+|--------|----------|------------------------|
+| String | False    | `"org.quiltmc:hashed"` |
 
-The intermediate mappings used for this mod. This field only officially supports `hashed` and `intermediary` currently.
+The intermediate mappings used for this mod. The intermediate mappings string must be a valid maven coordinate and match the `^[a-zA-Z0-9-_.]+:[a-zA-Z0-9-_.]+$` regular expresson. This field currently only officially supports `org.quiltmc:hashed` and `net.fabricmc:intermediary`.
 
 ### The `metadata` field 
 | Type   | Required |

--- a/specification/0002-quilt.mod.json.md
+++ b/specification/0002-quilt.mod.json.md
@@ -21,6 +21,7 @@ Below is an outline of all defined keys and values.
     * [breaks](#the-breaks-field) — Collection of mods that this mod is incompatible with
     * [load_type](#the-load_type-field) — How eagerly to load this mod
     * [repositories](#the-repositories-field) — Array of maven repositories
+    * [intermediate_mappings](#the-intermediate_mappings-field) — The intermediate mappings used
     * [metadata](#the-metadata-field) — Extra information about this mod and/or its authors
         * [name](#the-name-field) — Human-readable name of this mod
         * [description](#the-description-field) — Human-readable description of this mod
@@ -190,6 +191,13 @@ If this mod is in another mods "depends" field then it will be loaded, otherwise
 | Array  | False    |
 
 A list of Maven repository URL strings where dependencies can be looked for in addition to Quilt's central repository.
+
+### The `intermediate_mappings` field
+| Type   | Required |
+|--------|----------|
+| String | False    |
+
+The intermediate mappings used for this mod. This field only officially supports `hashed` and `intermediary` currently.
 
 ### The `metadata` field 
 | Type   | Required |

--- a/specification/0002-quilt.mod.json.md
+++ b/specification/0002-quilt.mod.json.md
@@ -193,9 +193,9 @@ If this mod is in another mods "depends" field then it will be loaded, otherwise
 A list of Maven repository URL strings where dependencies can be looked for in addition to Quilt's central repository.
 
 ### The `intermediate_mappings` field
-| Type   | Required |
-|--------|----------|
-| String | False    |
+| Type   | Required | Default    |
+|--------|----------|------------|
+| String | False    | `"hashed"` |
 
 The intermediate mappings used for this mod. This field only officially supports `hashed` and `intermediary` currently.
 


### PR DESCRIPTION
An amendment to RFC 2 per https://github.com/QuiltMC/quilt-loader/issues/59.

Adds an optional string field to `quilt.mod.json` in the `quilt_loader` section named `intermediate_mappings`. This string will be used to determine which mappings a mod uses once hashed support is added to QL. The two values it will accept are `"hashed"` and `"intermediary"`.