### PR TITLE
RFC 0064: Remove cheatsheet link

### DIFF
--- a/specification/0002-quilt.mod.json.md
+++ b/specification/0002-quilt.mod.json.md
@@ -467,8 +467,6 @@ A version range specifier can make use of any of the following patterns:
 * `~1.0.0` — Matches the most recent version greater than or equal to version 1.0.0 and less than 1.1.0
 * `^1.0.0` — Matches the most recent version greater than or equal to version 1.0.0 and less than 2.0.0
 
-See [this cheatsheet](https://devhints.io/semver) for more information. 
-
 # Drawbacks
 The primary drawback to this proposed format is the break from convention established by the Fabric project. It may make it more difficult for modders to adjust to the new toolchain if they are having to make drastic changes to their mod files.
 


### PR DESCRIPTION
@OroArmor added this about a week ago, however it references more functionality than what we actually support - namely hyphenated ranges and combined ranges (and/or). In addition I'd like to support this in a slightly different way (see #56), so this cheatsheet link is inaccurate.