### PR TITLE
RFC 0073: Quilt Community Collab Manager Elections

### DIFF
--- a/structure/0000-qcc-manager-elections.md
+++ b/structure/0000-qcc-manager-elections.md
@@ -1,0 +1,108 @@
+# RFC XXXX: Quilt Community Collab Manager Elections
+
+> [name=sciwhiz12]
+> - v1: Initial draft.
+> - v2:
+>   - Removed ability to nominate others to serve as Manager.
+>   - Expanded eligibility requirement to also require being of the age of majority, with a public declaration (or equivalent).
+> - v3: Expanded rationale for eligibility requirement to include the new 18+ requirement.
+> - v4: Resolved the question on what happens to current (and future) Quilt CMs, by having the initial set of Managers after this RFC's enactment be pulled from Quilt CMs through a new transitory provision.
+> - v5:
+>   - Added new provision where recall elections may also expel the Manager entirely from their position, instead of only removing the Manager role.
+>   - Added section on treatment of Managers with respect to their position as representatives of a participating community and the leave or removal of their community from the Program.
+>   - Added corresponding rationale for the above additions.
+
+## Summary
+This RFC describes the Managers for the Quilt Community Collab Program, in more detail than the original RFC, including processes to elect new Managers from Program members.
+
+For details about the Quilt Community Collab Program (henceforth the "Program"), including various terms used in this document, see [RFC 0062: Quilt Community Collab](https://github.com/QuiltMC/rfcs/blob/main/structure/0062-quilt-community-collab.md).
+
+## Motivation
+As of writing of this RFC, the current set of Managers for the Program is the same as the set of Community Managers for Quilt, under their Community Team as defined in [RFC 0007: Community Team](https://github.com/QuiltMC/rfcs/blob/main/structure/0007-community-team.md). When a new Community Manager is confirmed to their role, they are automatically confirmed to the role of Manager in the Program.
+
+The Program is structured for equality between all its participating communities, which is exemplified through the community-oriented voting process. However, all other participating communities other than Quilt have no representation as Managers. 
+
+As Quilt's Community Managers form the totality of the Managers of the Program (as of writing), Quilt exerts a great deal of influence on the Program's processes and functioning, outside of the principle of equality between communities. In addition, Quilt's Community Managers are active within Quilt itself by virtue of their position, which means they may be too busy at times to focus on the Program's functioning.
+
+The election of Managers from participating communities means there will be Managers that are independent of and not affiliated directly with Quilt (as part of their Community Team), and may have more capacity to handle and take care of the Program's functioning.
+
+## Explanation
+
+Once this RFC is put into effect, the initial set of Managers shall be formed from Community Managers of Quilt's Community Team (who as of writing are currently sitting *ex officio* as Program Managers) that have consented to being Managers. All future Managers shall be elected through the process described below.
+
+### Process: Electing a Manager
+Elections of Program Managers are handled in the following process:
+
+1. Eligible Program Members may nominate themselves to serve as a Manager of the Program by contacting a Manager. 
+   
+    A Program Member is eligible for nomination to be a Manager if they both hold the role of Collaborator or any role with equivalent access and rights, and are at least 18 years old, with a public declaration (or equivalent) to that effect.
+
+1. A public discussion is initiated by a Manager to determine if there is sufficient informal consensus among Program members to hold a vote to elect a new Manager.
+
+	The identity of the candidate and their prospects of a successful election are not the focus of this discussion.
+
+	The existence of sufficient informal consensus shall be established by either a Manager's discretion through observation of the resulting discussions, or at least 1/5 of all Program members signifying their consensus. If sufficient consensus is established in at most a week after the start of the discussion, the process will continue to the next stage.
+
+1. A vote is initiated on the election of the candidate as Manager, which shall be conducted in the manner prescribed in RFC 0062. The candidate shall provide an initial statement to be posted at the beginning of the vote.
+
+	**The vote has passed** when, at the time of closing, more than 75% of the votes cast are positive and there are no votes which have not been overruled.
+
+1. If the outcome of the vote is successful, the candidate shall now hold the role of Manager.
+
+If the candidate is rejected either through lack of informal consensus or a failed vote, the same candidate may not be nominated again until after a month has passed.
+
+If there is a lack of informal consensus after a consensus-building discussion, nominations shall not be entertained until after three days have passed.
+
+### Process: Recalling a Manager
+A Manager may be removed from their role as a Manager through a recall election. This recall election shall follow the same process as defined in RFC 0062 for removing a community.
+
+A recall election may be started by the Manager team, as outlined in the aforementioned process in RFC 0062, or through a signed petition of at least 40% of Program members or participating communities (as represented by their community members) presented to a Manager (in public or private).
+
+If the recall election succeeds, the Program member loses the role of Manager, retaining all other roles. However, before the vote is started, upon the decision of the Manager team or a signed petition of at least 40% of Program members or participating communities, the topic of the recall election's vote shall be expanded to include the expulsion of the Manager under recall from the Program entirely.
+
+In a recall election, the right to veto may not be exercised by Program members. The Manager under recall must not participate in the vote, but may participate in discussions if not otherwise disqualified by urgent circumstances.
+
+During a recall election, if urgent circumstances (as determined by the Manager team or the signed petition) require so, the roles of the Manager under recall may be temporarily replaced with the Invitee role. This removal of roles shall be communicated to the Manager under recall.
+
+If the vote of a recall election fails, the Manager under recall may not be subject to another recall election until after a month has passed.
+
+### Managers as Community Representatives
+
+A Manager may be a Collaborator by virtue of being a representative of a participating community.
+
+If a participating community is undergoing the removal process as defined in RFC 0062, then Managers representing that community shall be treated equally as all other representatives of that community, including the provisions on temporary role removal and reintegration.
+
+If a participating community voluntarily leaves, then Managers representing that community who would otherwise leave the Program (such as due to having no other role than Manager) upon that community's departure may choose to apply for another role within the Program if they wish to stay on as a Manager; otherwise, they must resign as a Manager and leave the Program.
+
+## Drawbacks
+- The addition of Managers from different backgrounds may be causes of conflict or disharmony within the Manager team.
+- The election and recall of Managers are still primarily driven by Managers themselves, as part of their responsibility for the functioning of the Program.
+- The processes herein are described in general terms, without specific references on what platforms it is conducted on. The specifics would be decided either through Manager discretion or consensus of Program member.
+
+## Rationale and Alternatives
+- The purpose of the eligibility requirements for Manager candidates is to ensure that Managers are Program members who are cleared to have access to sensitive moderation information by the Program's own processes, and they are of sufficient age to handle sensitive information which is not suitable (or legal) for handling by minors.
+- The purpose of the informal consensus-building discussion during Manager elections is to determine if Program members and communities feel that a vote on electing a new Manager is reasonable at that point in time. 
+
+	This is to avoid holding election votes which communities are likely to reject due to lack of consensus for having a new Manager, regardless of their identity. This is not meant to focus on if the candidate specifically will be elected, but whether there is sufficient interest to elect a Manager, whomever they may be.
+- The time limits imposed for lack of informal consensus and rejected nominations are in place to secure against wasting the Program members' time due to frivolous or repetitious nominations. The time limit on informal consensus is lesser on the basis that the consensus to elect a new Manager may change more quickly than the opinons of communities on a particular candidate.
+- The more democratic alternative of a signed petition as a way to initiate the recall election of a Manager is included to safeguard against a Manager's abuse of discretion, and to allow Program members to initiate proceedings against a Manager in private without the possibility that the Manager team may inform the Manager under recall.
+- A recall election may be concerned only with the performance of a Manager (or lack thereof), which does not otherwise affect their standing or reptuation. However, it may be concerned with more delicate/sensitive matters which affect the character of the Manager under recall. In the latter case, a way is provided to expel them from the Program entirely and promptly in a single vote.
+- Managers may be representatives of a participating community, and therefore are given the same scrutiny as that community's other representatives during processes such as proceedings to remove that community, since the assumption is that they support that community and may (inadvertently) leak information or unduly influence those proceedings in their role and authority as Manager.
+
+- Instead of allowing nominations at any time and discussing the consensus after that, what could be done is to first build consensus as to whether Manager elections should be held with a defined number of open positions.
+
+	After consensus is reached (through informal consensus or a formal vote), nominations may then be opened for those positions and then a more formal election process is held, different from the voting process defined in RFC 0062 by using an [electoral voting system](https://en.wikipedia.org/wiki/Electoral_system).
+- The amount of Managers may be apportioned to the amount of participating communities within the Program, to ensure representation of each community on the Manager team.
+- The recall election process may be genericized to be applicable against any Program member as a removal process.
+- The term "recall election" may be substituted, to avoid possible ambiguity on the meaning of the word "election".
+
+## Prior Art
+The idea for building (informal) consensus before holding a vote to elect a Manager is the combination of two concepts: the [English Wikipedia's concept of consensus](https://en.wikipedia.org/wiki/Wikipedia:Consensus), and the parliamentary procedure of a [second to a proposed mention](https://en.wikipedia.org/wiki/Second_(parliamentary_procedure)).
+
+In the English Wikipedia, decision making is not driven by unanimity or by the results of a vote, but through addressing and incorporting legitimate concerns raised through discussions. A second to a proposed motion is an indication that at least one other person desires to see the motion come before the body for further discussion and vote.
+
+A [recall election](https://en.wikipedia.org/wiki/Recall_election) is a procedure where voters can remove an elected official through a referendum before the end of their term of office. While the use of the term is novel in this RFC as compared to other RFCs, the concept behind it can be seen in many other RFCs such as RFC 0062, [RFC 0007: Community Team](https://github.com/QuiltMC/rfcs/blob/main/structure/0007-community-team.md), or [RFC 0006: Governmental Structure](https://github.com/QuiltMC/rfcs/blob/main/structure/0006-governance.md).
+
+## Unresolved Questions
+- What is the relationship of the Program's Manager team to Quilt's Community Team or Administrative Board?
+- What is the status of Quilt within the Program, due to it being the founding member and namesake of the Program?

--- a/structure/0000-qcc-manager-elections.md
+++ b/structure/0000-qcc-manager-elections.md
@@ -4,11 +4,11 @@
 
 This RFC describes the Managers for the Quilt Community Collab Program, in more detail than the original RFC, including processes to elect new Managers from Program members.
 
-For details about the Quilt Community Collab Program (henceforth the "Program"), including various terms used in this document, see [RFC 0062: Quilt Community Collab](https://github.com/QuiltMC/rfcs/blob/main/structure/0062-quilt-community-collab.md).
+For details about the Quilt Community Collab Program (henceforth the "Program"), including various terms used in this document, see [RFC 0062: Quilt Community Collab](/structure/0062-quilt-community-collab.md).
 
 ## Motivation
 
-As of writing of this RFC, the current set of Managers for the Program is the same as the set of Community Managers for Quilt, under their Community Team as defined in [RFC 0007: Community Team](https://github.com/QuiltMC/rfcs/blob/main/structure/0007-community-team.md). When a new Community Manager is confirmed to their role, they are automatically confirmed to the role of Manager in the Program.
+As of writing of this RFC, the current set of Managers for the Program is the same as the set of Community Managers for Quilt, under their Community Team as defined in [RFC 0007: Community Team](/structure/0007-community-team.md). When a new Community Manager is confirmed to their role, they are automatically confirmed to the role of Manager in the Program.
 
 The Program is structured for equality between all its participating communities, which is exemplified through the community-oriented voting process. However, all other participating communities other than Quilt have no representation as Managers.
 
@@ -100,7 +100,7 @@ The idea for building (informal) consensus before holding a vote to elect a Mana
 
 In the English Wikipedia, decision making is not driven by unanimity or by the results of a vote, but through addressing and incorporting legitimate concerns raised through discussions. A second to a proposed motion is an indication that at least one other person desires to see the motion come before the body for further discussion and vote.
 
-A [recall election](https://en.wikipedia.org/wiki/Recall_election) is a procedure where voters can remove an elected official through a referendum before the end of their term of office. While the use of the term is novel in this RFC as compared to other RFCs, the concept behind it can be seen in many other RFCs such as RFC 0062, [RFC 0007: Community Team](https://github.com/QuiltMC/rfcs/blob/main/structure/0007-community-team.md), or [RFC 0006: Governmental Structure](https://github.com/QuiltMC/rfcs/blob/main/structure/0006-governance.md).
+A [recall election](https://en.wikipedia.org/wiki/Recall_election) is a procedure where voters can remove an elected official through a referendum before the end of their term of office. While the use of the term is novel in this RFC as compared to other RFCs, the concept behind it can be seen in many other RFCs such as RFC 0062, [RFC 0007: Community Team](/structure/0007-community-team.md), or [RFC 0006: Governmental Structure](/structure/0006-governance.md).
 
 ## Unresolved Questions
 

--- a/structure/0000-qcc-manager-elections.md
+++ b/structure/0000-qcc-manager-elections.md
@@ -1,26 +1,16 @@
-# RFC XXXX: Quilt Community Collab Manager Elections
-
-> [name=sciwhiz12]
-> - v1: Initial draft.
-> - v2:
->   - Removed ability to nominate others to serve as Manager.
->   - Expanded eligibility requirement to also require being of the age of majority, with a public declaration (or equivalent).
-> - v3: Expanded rationale for eligibility requirement to include the new 18+ requirement.
-> - v4: Resolved the question on what happens to current (and future) Quilt CMs, by having the initial set of Managers after this RFC's enactment be pulled from Quilt CMs through a new transitory provision.
-> - v5:
->   - Added new provision where recall elections may also expel the Manager entirely from their position, instead of only removing the Manager role.
->   - Added section on treatment of Managers with respect to their position as representatives of a participating community and the leave or removal of their community from the Program.
->   - Added corresponding rationale for the above additions.
+# RFC 0000: Quilt Community Collab Manager Elections
 
 ## Summary
+
 This RFC describes the Managers for the Quilt Community Collab Program, in more detail than the original RFC, including processes to elect new Managers from Program members.
 
 For details about the Quilt Community Collab Program (henceforth the "Program"), including various terms used in this document, see [RFC 0062: Quilt Community Collab](https://github.com/QuiltMC/rfcs/blob/main/structure/0062-quilt-community-collab.md).
 
 ## Motivation
+
 As of writing of this RFC, the current set of Managers for the Program is the same as the set of Community Managers for Quilt, under their Community Team as defined in [RFC 0007: Community Team](https://github.com/QuiltMC/rfcs/blob/main/structure/0007-community-team.md). When a new Community Manager is confirmed to their role, they are automatically confirmed to the role of Manager in the Program.
 
-The Program is structured for equality between all its participating communities, which is exemplified through the community-oriented voting process. However, all other participating communities other than Quilt have no representation as Managers. 
+The Program is structured for equality between all its participating communities, which is exemplified through the community-oriented voting process. However, all other participating communities other than Quilt have no representation as Managers.
 
 As Quilt's Community Managers form the totality of the Managers of the Program (as of writing), Quilt exerts a great deal of influence on the Program's processes and functioning, outside of the principle of equality between communities. In addition, Quilt's Community Managers are active within Quilt itself by virtue of their position, which means they may be too busy at times to focus on the Program's functioning.
 
@@ -31,21 +21,22 @@ The election of Managers from participating communities means there will be Mana
 Once this RFC is put into effect, the initial set of Managers shall be formed from Community Managers of Quilt's Community Team (who as of writing are currently sitting *ex officio* as Program Managers) that have consented to being Managers. All future Managers shall be elected through the process described below.
 
 ### Process: Electing a Manager
+
 Elections of Program Managers are handled in the following process:
 
-1. Eligible Program Members may nominate themselves to serve as a Manager of the Program by contacting a Manager. 
-   
+1. Eligible Program Members may nominate themselves to serve as a Manager of the Program by contacting a Manager.
+
     A Program Member is eligible for nomination to be a Manager if they both hold the role of Collaborator or any role with equivalent access and rights, and are at least 18 years old, with a public declaration (or equivalent) to that effect.
 
 1. A public discussion is initiated by a Manager to determine if there is sufficient informal consensus among Program members to hold a vote to elect a new Manager.
 
-	The identity of the candidate and their prospects of a successful election are not the focus of this discussion.
+    The identity of the candidate and their prospects of a successful election are not the focus of this discussion.
 
-	The existence of sufficient informal consensus shall be established by either a Manager's discretion through observation of the resulting discussions, or at least 1/5 of all Program members signifying their consensus. If sufficient consensus is established in at most a week after the start of the discussion, the process will continue to the next stage.
+    The existence of sufficient informal consensus shall be established by either a Manager's discretion through observation of the resulting discussions, or at least 1/5 of all Program members signifying their consensus. If sufficient consensus is established in at most a week after the start of the discussion, the process will continue to the next stage.
 
 1. A vote is initiated on the election of the candidate as Manager, which shall be conducted in the manner prescribed in RFC 0062. The candidate shall provide an initial statement to be posted at the beginning of the vote.
 
-	**The vote has passed** when, at the time of closing, more than 75% of the votes cast are positive and there are no votes which have not been overruled.
+    **The vote has passed** when, at the time of closing, more than 75% of the votes cast are positive and there are no votes which have not been overruled.
 
 1. If the outcome of the vote is successful, the candidate shall now hold the role of Manager.
 
@@ -54,6 +45,7 @@ If the candidate is rejected either through lack of informal consensus or a fail
 If there is a lack of informal consensus after a consensus-building discussion, nominations shall not be entertained until after three days have passed.
 
 ### Process: Recalling a Manager
+
 A Manager may be removed from their role as a Manager through a recall election. This recall election shall follow the same process as defined in RFC 0062 for removing a community.
 
 A recall election may be started by the Manager team, as outlined in the aforementioned process in RFC 0062, or through a signed petition of at least 40% of Program members or participating communities (as represented by their community members) presented to a Manager (in public or private).
@@ -75,28 +67,35 @@ If a participating community is undergoing the removal process as defined in RFC
 If a participating community voluntarily leaves, then Managers representing that community who would otherwise leave the Program (such as due to having no other role than Manager) upon that community's departure may choose to apply for another role within the Program if they wish to stay on as a Manager; otherwise, they must resign as a Manager and leave the Program.
 
 ## Drawbacks
+
 - The addition of Managers from different backgrounds may be causes of conflict or disharmony within the Manager team.
 - The election and recall of Managers are still primarily driven by Managers themselves, as part of their responsibility for the functioning of the Program.
 - The processes herein are described in general terms, without specific references on what platforms it is conducted on. The specifics would be decided either through Manager discretion or consensus of Program member.
 
 ## Rationale and Alternatives
-- The purpose of the eligibility requirements for Manager candidates is to ensure that Managers are Program members who are cleared to have access to sensitive moderation information by the Program's own processes, and they are of sufficient age to handle sensitive information which is not suitable (or legal) for handling by minors.
-- The purpose of the informal consensus-building discussion during Manager elections is to determine if Program members and communities feel that a vote on electing a new Manager is reasonable at that point in time. 
 
-	This is to avoid holding election votes which communities are likely to reject due to lack of consensus for having a new Manager, regardless of their identity. This is not meant to focus on if the candidate specifically will be elected, but whether there is sufficient interest to elect a Manager, whomever they may be.
+### Rationale
+
+- The purpose of the eligibility requirements for Manager candidates is to ensure that Managers are Program members who are cleared to have access to sensitive moderation information by the Program's own processes, and they are of sufficient age to handle sensitive information which is not suitable (or legal) for handling by minors.
+- The purpose of the informal consensus-building discussion during Manager elections is to determine if Program members and communities feel that a vote on electing a new Manager is reasonable at that point in time.
+
+    This is to avoid holding election votes which communities are likely to reject due to lack of consensus for having a new Manager, regardless of their identity. This is not meant to focus on if the candidate specifically will be elected, but whether there is sufficient interest to elect a Manager, whomever they may be.
 - The time limits imposed for lack of informal consensus and rejected nominations are in place to secure against wasting the Program members' time due to frivolous or repetitious nominations. The time limit on informal consensus is lesser on the basis that the consensus to elect a new Manager may change more quickly than the opinons of communities on a particular candidate.
 - The more democratic alternative of a signed petition as a way to initiate the recall election of a Manager is included to safeguard against a Manager's abuse of discretion, and to allow Program members to initiate proceedings against a Manager in private without the possibility that the Manager team may inform the Manager under recall.
 - A recall election may be concerned only with the performance of a Manager (or lack thereof), which does not otherwise affect their standing or reptuation. However, it may be concerned with more delicate/sensitive matters which affect the character of the Manager under recall. In the latter case, a way is provided to expel them from the Program entirely and promptly in a single vote.
 - Managers may be representatives of a participating community, and therefore are given the same scrutiny as that community's other representatives during processes such as proceedings to remove that community, since the assumption is that they support that community and may (inadvertently) leak information or unduly influence those proceedings in their role and authority as Manager.
 
+### Alternatives
+
 - Instead of allowing nominations at any time and discussing the consensus after that, what could be done is to first build consensus as to whether Manager elections should be held with a defined number of open positions.
 
-	After consensus is reached (through informal consensus or a formal vote), nominations may then be opened for those positions and then a more formal election process is held, different from the voting process defined in RFC 0062 by using an [electoral voting system](https://en.wikipedia.org/wiki/Electoral_system).
+    After consensus is reached (through informal consensus or a formal vote), nominations may then be opened for those positions and then a more formal election process is held, different from the voting process defined in RFC 0062 by using an [electoral voting system](https://en.wikipedia.org/wiki/Electoral_system).
 - The amount of Managers may be apportioned to the amount of participating communities within the Program, to ensure representation of each community on the Manager team.
 - The recall election process may be genericized to be applicable against any Program member as a removal process.
 - The term "recall election" may be substituted, to avoid possible ambiguity on the meaning of the word "election".
 
 ## Prior Art
+
 The idea for building (informal) consensus before holding a vote to elect a Manager is the combination of two concepts: the [English Wikipedia's concept of consensus](https://en.wikipedia.org/wiki/Wikipedia:Consensus), and the parliamentary procedure of a [second to a proposed mention](https://en.wikipedia.org/wiki/Second_(parliamentary_procedure)).
 
 In the English Wikipedia, decision making is not driven by unanimity or by the results of a vote, but through addressing and incorporting legitimate concerns raised through discussions. A second to a proposed motion is an indication that at least one other person desires to see the motion come before the body for further discussion and vote.
@@ -104,5 +103,6 @@ In the English Wikipedia, decision making is not driven by unanimity or by the r
 A [recall election](https://en.wikipedia.org/wiki/Recall_election) is a procedure where voters can remove an elected official through a referendum before the end of their term of office. While the use of the term is novel in this RFC as compared to other RFCs, the concept behind it can be seen in many other RFCs such as RFC 0062, [RFC 0007: Community Team](https://github.com/QuiltMC/rfcs/blob/main/structure/0007-community-team.md), or [RFC 0006: Governmental Structure](https://github.com/QuiltMC/rfcs/blob/main/structure/0006-governance.md).
 
 ## Unresolved Questions
+
 - What is the relationship of the Program's Manager team to Quilt's Community Team or Administrative Board?
 - What is the status of Quilt within the Program, due to it being the founding member and namesake of the Program?

--- a/structure/0062-quilt-community-collab.md
+++ b/structure/0062-quilt-community-collab.md
@@ -247,4 +247,4 @@ Additionally, the Quilt Community Collab Program has a much broader focus --- at
 
 For the sake of getting this process document completed within a reasonable amount of time, the following concerns will need to be addressed at a later date:
 
-* We haven't discussed how new Managers should be added, which is an issue due to the fact that all Program Managers are also Quilt Community Managers; a more representative level of power-sharing should be worked on
+* ~~We haven't discussed how new Managers should be added, which is an issue due to the fact that all Program Managers are also Quilt Community Managers; a more representative level of power-sharing should be worked on.~~ This question has been resolved by [RFC 0000: Quilt Community Collab Manager Elections](/structure/0000-qcc-manager-elections.md).

--- a/structure/0062-quilt-community-collab.md
+++ b/structure/0062-quilt-community-collab.md
@@ -247,4 +247,4 @@ Additionally, the Quilt Community Collab Program has a much broader focus --- at
 
 For the sake of getting this process document completed within a reasonable amount of time, the following concerns will need to be addressed at a later date:
 
-* ~~We haven't discussed how new Managers should be added, which is an issue due to the fact that all Program Managers are also Quilt Community Managers; a more representative level of power-sharing should be worked on.~~ This question has been resolved by [RFC 0000: Quilt Community Collab Manager Elections](/structure/0000-qcc-manager-elections.md).
+* ~~We haven't discussed how new Managers should be added, which is an issue due to the fact that all Program Managers are also Quilt Community Managers; a more representative level of power-sharing should be worked on.~~ This question has been resolved by [RFC 0073: Quilt Community Collab Manager Elections](/structure/0073-qcc-manager-elections.md).

--- a/structure/0073-qcc-manager-elections.md
+++ b/structure/0073-qcc-manager-elections.md
@@ -1,4 +1,4 @@
-# RFC 0000: Quilt Community Collab Manager Elections
+# RFC 0073: Quilt Community Collab Manager Elections
 
 ## Summary
 


### PR DESCRIPTION
To quote the summary of the RFC,

>  This RFC describes the Managers for the Quilt Community Collab Program, in more detail than the original RFC, including processes to elect new Managers from Program members.

The one remaining [unresolved question in RFC 0062: Quilt Community Collab](https://github.com/QuiltMC/rfcs/blob/main/structure/0062-quilt-community-collab.md#unresolved-questions) is the determination of who the Program's Managers are. As of now, Quilt's Community Managers sit as _ex officio_ Managers. This was fine in the beginning when details of the collab were being sorted out, but now we come at a point where it is important to have diversification of the responsibilities and duties held by Managers across the participating communities of the Program, rather than those being solely in the hands of Quilt.

---

This RFC is the result of discussions held in the Quilt Community Collab server. For historical purposes, the first commit is the unedited, raw version of the final draft before the publication of this RFC PR. The original draft was hosted on [my personal HackMD workspace](https://hackmd.io/@sciwhiz12/rfc-qcc-manager-elections).[^1]

The RFC calls for the initial set of Managers after this PR's enactment to be pulled from Quilt Community Managers who have consented to being a Manager for the Program. In accordance with this, @gdude2002 and @Akarys42 have agreed to be the initial Managers.

[**Rendered View**](https://github.com/sciwhiz12/quiltmc-rfcs/blob/proposal/qcc-manager-elections/structure/0073-qcc-manager-elections.md)

[^1]: If this link should ever rot, know that its contents is literally the same as the first commit of this PR.